### PR TITLE
[Added] endpoint to finsh a ride

### DIFF
--- a/api/handlers/errors.go
+++ b/api/handlers/errors.go
@@ -37,6 +37,16 @@ func ErrStartDB(err error) render.Renderer {
 		ErrorText:      err.Error(),
 	}
 }
+
+func ErrFinishDB(err error) render.Renderer {
+	return &ErrResponse{
+		Err:            err,
+		HTTPStatusCode: 500,
+		StatusText:     "Error while finishing ride.",
+		ErrorText:      err.Error(),
+	}
+}
+
 func ErrFindDB(err error) render.Renderer {
 	return &ErrResponse{
 		Err:            err,

--- a/rides/finish.go
+++ b/rides/finish.go
@@ -1,0 +1,35 @@
+package rides
+
+import (
+	"context"
+	"math"
+	"time"
+
+	"backend/utils"
+
+	"github.com/go-rel/rel"
+)
+
+type finishRide struct {
+	repository rel.Repository
+}
+
+func (c startRide) FinishRide(ctx context.Context, ride *Ride, now time.Time) (error, *Ride) {
+	var (
+		duration    = now.Sub(ride.CreatedAt)
+		seconds     = duration.Seconds()
+		minutes     = int(math.Ceil(seconds / 60))
+		minutePrice = utils.GetEnvAsInt("RIDE_MINUTE_PRICE", 100)
+	)
+
+	count, _ := c.repository.Count(ctx, "rides", rel.And(rel.Eq("id", ride.ID), rel.Eq("finished", true)))
+	if count != 0 {
+		return ErrRideAlreadyFinished, nil
+	}
+
+	ride.Price = ride.Price + minutes*minutePrice
+	ride.Finished = true
+
+	err := c.repository.Update(ctx, ride)
+	return err, ride
+}

--- a/rides/finish_test.go
+++ b/rides/finish_test.go
@@ -1,0 +1,156 @@
+package rides
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/go-rel/rel"
+	"github.com/go-rel/reltest"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFinish1Second(t *testing.T) {
+	var (
+		ctx        = context.TODO()
+		repository = reltest.New()
+		service    = New(repository)
+		now        = time.Now()
+		createdAt  = now.Add(-time.Second * 1)
+		ride       = Ride{ID: 1, UserID: "1", VehicleID: "1", Price: 18, CreatedAt: createdAt, UpdatedAt: createdAt, Finished: false}
+	)
+
+	repository.ExpectCount("rides", rel.And(rel.Eq("id", ride.ID), rel.Eq("finished", true))).Result(0)
+	repository.ExpectUpdate().For(&ride)
+
+	err, _ := service.FinishRide(ctx, &ride, now)
+	assert.Nil(t, err)
+	assert.Equal(t, ride.Price, 118)
+	assert.NotEmpty(t, ride.UpdatedAt)
+	assert.True(t, ride.Finished)
+
+	repository.AssertExpectations(t)
+}
+
+func TestFinish10Seconds(t *testing.T) {
+	var (
+		ctx        = context.TODO()
+		repository = reltest.New()
+		service    = New(repository)
+		now        = time.Now()
+		createdAt  = now.Add(-time.Second * 10)
+		ride       = Ride{ID: 1, UserID: "1", VehicleID: "1", Price: 18, CreatedAt: createdAt, UpdatedAt: createdAt, Finished: false}
+	)
+
+	repository.ExpectCount("rides", rel.And(rel.Eq("id", ride.ID), rel.Eq("finished", true))).Result(0)
+	repository.ExpectUpdate().For(&ride)
+
+	err, _ := service.FinishRide(ctx, &ride, now)
+	assert.Nil(t, err)
+	assert.Equal(t, ride.Price, 118)
+	assert.True(t, ride.Finished)
+
+	repository.AssertExpectations(t)
+}
+
+func TestFinish59Seconds(t *testing.T) {
+	var (
+		ctx        = context.TODO()
+		repository = reltest.New()
+		service    = New(repository)
+		now        = time.Now()
+		createdAt  = now.Add(-time.Second * 59)
+		ride       = Ride{ID: 1, UserID: "1", VehicleID: "1", Price: 18, CreatedAt: createdAt, UpdatedAt: createdAt, Finished: false}
+	)
+
+	repository.ExpectCount("rides", rel.And(rel.Eq("id", ride.ID), rel.Eq("finished", true))).Result(0)
+	repository.ExpectUpdate().For(&ride)
+
+	err, _ := service.FinishRide(ctx, &ride, now)
+	assert.Nil(t, err)
+	assert.Equal(t, ride.Price, 118)
+	assert.True(t, ride.Finished)
+
+	repository.AssertExpectations(t)
+}
+
+func TestFinish60Seconds(t *testing.T) {
+	var (
+		ctx        = context.TODO()
+		repository = reltest.New()
+		service    = New(repository)
+		now        = time.Now()
+		createdAt  = now.Add(-time.Second * 60)
+		ride       = Ride{ID: 1, UserID: "1", VehicleID: "1", Price: 18, CreatedAt: createdAt, UpdatedAt: createdAt, Finished: false}
+	)
+
+	repository.ExpectCount("rides", rel.And(rel.Eq("id", ride.ID), rel.Eq("finished", true))).Result(0)
+	repository.ExpectUpdate().For(&ride)
+
+	err, _ := service.FinishRide(ctx, &ride, now)
+	assert.Nil(t, err)
+	assert.Equal(t, ride.Price, 118)
+	assert.True(t, ride.Finished)
+
+	repository.AssertExpectations(t)
+}
+
+func TestFinish61Seconds(t *testing.T) {
+	var (
+		ctx        = context.TODO()
+		repository = reltest.New()
+		service    = New(repository)
+		now        = time.Now()
+		createdAt  = now.Add(-time.Second * 61)
+		ride       = Ride{ID: 1, UserID: "1", VehicleID: "1", Price: 18, CreatedAt: createdAt, UpdatedAt: createdAt, Finished: false}
+	)
+
+	repository.ExpectCount("rides", rel.And(rel.Eq("id", ride.ID), rel.Eq("finished", true))).Result(0)
+	repository.ExpectUpdate().For(&ride)
+
+	err, _ := service.FinishRide(ctx, &ride, now)
+	assert.Nil(t, err)
+	assert.Equal(t, ride.Price, 218)
+	assert.True(t, ride.Finished)
+
+	repository.AssertExpectations(t)
+}
+
+func TestFinish1565Seconds(t *testing.T) {
+	var (
+		ctx        = context.TODO()
+		repository = reltest.New()
+		service    = New(repository)
+		now        = time.Now()
+		createdAt  = now.Add(-time.Second * 1565)
+		ride       = Ride{ID: 1, UserID: "1", VehicleID: "1", Price: 18, CreatedAt: createdAt, UpdatedAt: createdAt, Finished: false}
+	)
+
+	repository.ExpectCount("rides", rel.And(rel.Eq("id", ride.ID), rel.Eq("finished", true))).Result(0)
+	repository.ExpectUpdate().For(&ride)
+
+	err, _ := service.FinishRide(ctx, &ride, now)
+	assert.Nil(t, err)
+	assert.Equal(t, ride.Price, 2718)
+	assert.True(t, ride.Finished)
+
+	repository.AssertExpectations(t)
+}
+
+func TestFinishRideAlreadyFinished(t *testing.T) {
+	var (
+		ctx        = context.TODO()
+		repository = reltest.New()
+		service    = New(repository)
+		now        = time.Now()
+		createdAt  = now.Add(-time.Second * 1565)
+		ride       = Ride{ID: 1, UserID: "1", VehicleID: "1", Price: 18, CreatedAt: createdAt, UpdatedAt: createdAt, Finished: false}
+	)
+
+	repository.ExpectCount("rides", rel.And(rel.Eq("id", ride.ID), rel.Eq("finished", true))).Result(1)
+
+	err, _ := service.FinishRide(ctx, &ride, now)
+	assert.Equal(t, ErrRideAlreadyFinished, err)
+
+	repository.AssertExpectations(t)
+}

--- a/rides/ride.go
+++ b/rides/ride.go
@@ -19,6 +19,7 @@ var (
 	ErrRideUserIDBlank    = errors.New("UserID can't be blank")
 	ErrRideVehicleIDBlank = errors.New("VehicleID can't be blank")
 	ErrRideAlreadyStarted = errors.New("A ride is already started for this vehicle or user")
+	ErrRideAlreadyFinished = errors.New("This ride is already finished")
 )
 
 func (r Ride) Validate() error {

--- a/rides/service.go
+++ b/rides/service.go
@@ -2,20 +2,24 @@ package rides
 
 import (
 	"context"
+	"time"
 
 	"github.com/go-rel/rel"
 )
 
 type Service interface {
 	StartRide(ctx context.Context, ride *Ride) (error, *Ride)
+	FinishRide(ctx context.Context, ride *Ride, now time.Time) (error, *Ride)
 }
 
 type service struct {
 	startRide
+	finishRide
 }
 
 func New(repository rel.Repository) Service {
 	return service{
 		startRide: startRide{repository: repository},
+		finishRide: finishRide{repository: repository},
 	}
 }


### PR DESCRIPTION
This PR creates the `POST /rides/:id/finish` endpoint to finish a ride.

In detail, it adds the following:
- endpoint to finish a ride
- endpoint data validation
   - Do not finish a ride the ride is already finished.
   - Do not start a ride if the ride does not exist.
- price calculation
- tests